### PR TITLE
Add test webpage for server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ xcode/MarkDownload - Markdown Web Clipper/MarkDownload - Markdown Web Clipper.xc
 xcode/MarkDownload - Markdown Web Clipper/MarkDownload - Markdown Web Clipper.xcodeproj/xcuserdata
 .DS_Store
 node_modules
+server/output/

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,8 @@ const {
 
 const app = express();
 app.use(express.json({ limit: '10mb' }));
+const PUBLIC_DIR = path.join(__dirname, 'public');
+app.use(express.static(PUBLIC_DIR));
 
 const OUTPUT_DIR = path.join(__dirname, 'output');
 fs.mkdirSync(OUTPUT_DIR, { recursive: true });

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>MarkDownload Server Test</title>
+  <style>
+    body { font-family: sans-serif; margin: 2em; }
+    #result { white-space: pre-wrap; border: 1px solid #ccc; padding: 1em; margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <h1>MarkDownload Server Test</h1>
+  <input id="url" type="text" placeholder="Enter URL" size="50" />
+  <button id="clip">Clip</button>
+  <pre id="result"></pre>
+  <script>
+    document.getElementById('clip').addEventListener('click', async () => {
+      const url = document.getElementById('url').value;
+      if (!url) return;
+      const res = await fetch('/clip', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url })
+      });
+      const data = await res.json();
+      if (data.markdown) {
+        document.getElementById('result').textContent = data.markdown;
+      } else {
+        document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve static files from `server/public`
- include a basic webpage to send URL to `/clip`
- ignore server output files

## Testing
- `npm test` in `server`
- `npm run lint` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68652e21627c832ab244a5d6a16a2b13