### PR TITLE
Fix server default options

### DIFF
--- a/server/markdownload.js
+++ b/server/markdownload.js
@@ -24,7 +24,7 @@ const defaultOptions = {
   frontmatter: "---\ncreated: {date:YYYY-MM-DDTHH:mm:ss} (UTC {date:Z})\ntags: [{keywords}]\nsource: {baseURI}\nauthor: {byline}\n---\n\n# {pageTitle}\n\n> ## Excerpt\n> {excerpt}\n\n---",
   backmatter: "",
   title: "{pageTitle}",
-  includeTemplate: false,
+  includeTemplate: true,
   saveAs: false,
   downloadImages: false,
   imagePrefix: "{pageTitle}/",


### PR DESCRIPTION
## Summary
- enable template frontmatter by default in the server

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68653a92c74c832ab386261d71e3af1a