### PR TITLE
Improve server test page UI

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,8 @@ const { v4: uuidv4 } = require('uuid');
 const fetch = global.fetch;
 const {
   getArticleFromDom,
-  convertArticleToMarkdown
+  convertArticleToMarkdown,
+  getOptions
 } = require('./markdownload');
 
 const app = express();
@@ -15,6 +16,10 @@ app.use(express.static(PUBLIC_DIR));
 
 const OUTPUT_DIR = path.join(__dirname, 'output');
 fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+
+app.get('/options', (req, res) => {
+  res.json(getOptions());
+});
 
 app.post('/clip', async (req, res) => {
   const { url, options = {} } = req.body;

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -5,28 +5,88 @@
   <title>MarkDownload Server Test</title>
   <style>
     body { font-family: sans-serif; margin: 2em; }
-    #result { white-space: pre-wrap; border: 1px solid #ccc; padding: 1em; margin-top: 1em; }
+    #top { margin-bottom: 1em; }
+    #container { display: flex; }
+    #params { width: 30%; margin-right: 1em; }
+    #markdown { flex: 1; white-space: pre-wrap; border: 1px solid #ccc; padding: 1em; }
+    #loading {
+      display: none;
+      border: 4px solid #f3f3f3;
+      border-top: 4px solid #555;
+      border-radius: 50%;
+      width: 16px;
+      height: 16px;
+      animation: spin 1s linear infinite;
+      margin-left: 0.5em;
+    }
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    #params div { margin-bottom: 0.5em; }
+    #params label { display: block; font-weight: bold; }
   </style>
 </head>
 <body>
   <h1>MarkDownload Server Test</h1>
-  <input id="url" type="text" placeholder="Enter URL" size="50" />
-  <button id="clip">Clip</button>
-  <pre id="result"></pre>
+  <div id="top">
+    <input id="url" type="text" placeholder="Enter URL" size="50" />
+    <button id="clip">Clip</button>
+    <span id="loading"></span>
+  </div>
+  <div id="container">
+    <div id="params"></div>
+    <pre id="markdown"></pre>
+  </div>
   <script>
+    let defaultOptions = {};
+    async function loadOptions() {
+      const res = await fetch('/options');
+      defaultOptions = await res.json();
+      const params = document.getElementById('params');
+      for (const [key, value] of Object.entries(defaultOptions)) {
+        const row = document.createElement('div');
+        const label = document.createElement('label');
+        label.textContent = key;
+        label.htmlFor = key;
+        let input = document.createElement('input');
+        if (typeof value === 'boolean') {
+          input.type = 'checkbox';
+          input.checked = value;
+        } else {
+          input.type = 'text';
+          input.value = value ?? '';
+        }
+        input.id = key;
+        row.appendChild(label);
+        row.appendChild(input);
+        params.appendChild(row);
+      }
+    }
+    loadOptions();
+
     document.getElementById('clip').addEventListener('click', async () => {
       const url = document.getElementById('url').value;
       if (!url) return;
+      const options = {};
+      for (const key of Object.keys(defaultOptions)) {
+        const el = document.getElementById(key);
+        if (el.type === 'checkbox') options[key] = el.checked;
+        else options[key] = el.value;
+      }
+      document.getElementById('loading').style.display = 'inline-block';
       const res = await fetch('/clip', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url })
+        body: JSON.stringify({ url, options })
       });
       const data = await res.json();
+      document.getElementById('loading').style.display = 'none';
+      const output = document.getElementById('markdown');
       if (data.markdown) {
-        document.getElementById('result').textContent = data.markdown;
+        output.textContent = data.markdown;
       } else {
-        document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+        output.textContent = JSON.stringify(data, null, 2);
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- expose default options via `/options` endpoint
- revamp test page layout with params list and markdown area
- add loading spinner while waiting for server response

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686561ab60d0832a9c87af0c0ab74c14