### PR TITLE
Add server send URL option

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -562,6 +562,9 @@ async function notify(message) {
   else if (message.type == "download") {
     downloadMarkdown(message.markdown, message.title, message.tab.id, message.imageList, message.mdClipsFolder);
   }
+  else if (message.type == "send-url") {
+    sendUrlToServer(message.url);
+  }
 }
 
 browser.commands.onCommand.addListener(function (command) {
@@ -617,6 +620,9 @@ browser.contextMenus.onClicked.addListener(function (info, tab) {
   }
   else if (info.menuItemId.startsWith("copy-tab-as-markdown-link")) {
     copyTabAsMarkdownLink(tab);
+  }
+  else if (info.menuItemId == "send-url-to-server") {
+    sendUrlToServer(tab.url);
   }
   // a settings toggle command
   else if (info.menuItemId.startsWith("toggle-") || info.menuItemId.startsWith("tabtoggle-")) {
@@ -1003,6 +1009,20 @@ async function downloadMarkdownForAllTabs(info) {
   tabs.forEach(tab => {
     downloadMarkdownFromContext(info, tab);
   });
+}
+
+async function sendUrlToServer(url) {
+  const options = await getOptions();
+  if (!options.serverEndpoint) return;
+  try {
+    await fetch(options.serverEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url })
+    });
+  } catch (err) {
+    console.error('Failed to send URL to server', err);
+  }
 }
 
 /**

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -128,6 +128,11 @@ More information:  <a href="https://vinzent03.github.io/obsidian-advanced-uri/">
             <input type="text" name="obsidianFolder" role="textbox" placeholder="Enter Folder Name eg. Clippers"/>
         </div>
 
+        <div class="textbox-container" id="serverEndpoint">
+            <label for="serverEndpoint">Server Endpoint:</label>
+            <input type="text" name="serverEndpoint" role="textbox" placeholder="http://localhost:3000/clip" />
+        </div>
+
         <br />
 
         <div class="radio-container" id="downloadMode">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -20,6 +20,7 @@ const saveOptions = e => {
         obsidianIntegration: document.querySelector("[name='obsidianIntegration']").checked,
         obsidianVault: document.querySelector("[name='obsidianVault']").value,
         obsidianFolder: document.querySelector("[name='obsidianFolder']").value,
+        serverEndpoint: document.querySelector("[name='serverEndpoint']").value,
 
         headingStyle: getCheckedValue(document.querySelectorAll("input[name='headingStyle']")),
         hr: getCheckedValue(document.querySelectorAll("input[name='hr']")),
@@ -124,6 +125,7 @@ const setCurrentChoice = result => {
     document.querySelector("[name='obsidianIntegration']").checked = options.obsidianIntegration;
     document.querySelector("[name='obsidianVault']").value = options.obsidianVault;
     document.querySelector("[name='obsidianFolder']").value = options.obsidianFolder;
+    document.querySelector("[name='serverEndpoint']").value = options.serverEndpoint;
 
     setCheckedValue(document.querySelectorAll("[name='headingStyle']"), options.headingStyle);
     setCheckedValue(document.querySelectorAll("[name='hr']"), options.hr);

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -24,6 +24,7 @@
     <textarea id="md"></textarea>
     <a href="#" class="button" id="download">Download</a>
     <a href="#" class="button" id="downloadSelection">Download selected</a>
+    <a href="#" class="button" id="sendUrl">Send URL to Server</a>
   </div>
   <div id="spinner"></div>
   <script type="application/javascript" src="../browser-polyfill.min.js"></script>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -24,6 +24,7 @@ cm.on("cursorActivity", (cm) => {
 });
 document.getElementById("download").addEventListener("click", download);
 document.getElementById("downloadSelection").addEventListener("click", downloadSelection);
+document.getElementById("sendUrl").addEventListener("click", sendUrlToServer);
 
 const defaultOptions = {
     includeTemplate: false,
@@ -210,6 +211,15 @@ async function downloadSelection(e) {
     if (cm.somethingSelected()) {
         await sendDownloadMessage(cm.getSelection());
     }
+}
+
+// event handler for send URL button
+async function sendUrlToServer(e) {
+    e.preventDefault();
+    const tabs = await browser.tabs.query({ currentWindow: true, active: true });
+    const url = tabs[0].url;
+    await browser.runtime.sendMessage({ type: "send-url", url });
+    window.close();
 }
 
 //function that handles messages from the injected script into the site

--- a/src/shared/context-menus.js
+++ b/src/shared/context-menus.js
@@ -148,6 +148,14 @@ async function createMenus() {
         contexts: ["all"]
       }, () => { });
     }
+
+    if(options.serverEndpoint){
+      browser.contextMenus.create({
+        id: "send-url-to-server",
+        title: "Send Tab URL to Server",
+        contexts: ["all"]
+      }, () => { });
+    }
     browser.contextMenus.create({
       id: "separator-3",
       type: "separator",

--- a/src/shared/default-options.js
+++ b/src/shared/default-options.js
@@ -26,6 +26,7 @@ const defaultOptions = {
   obsidianIntegration: false,
   obsidianVault: "",
   obsidianFolder: "",
+  serverEndpoint: "",
 }
 
 // function to get the options from storage and substitute default options if it fails


### PR DESCRIPTION
## Summary
- add `serverEndpoint` option with input field
- allow sending tab URL to server via popup button and context menu

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865a8658e48832abc7a93a0477f3e9b