### PR TITLE
Fix puppeteer option and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,19 @@ You need to do some configurations in order to use this integration.
 
 Run `npm install` inside the `server` folder and start the server with `npm start`.
 The service exposes a `POST /clip` endpoint accepting a JSON body `{ "url": "<target url>", "options": { ... } }` and returns an identifier and markdown content. Pass `"puppeteer": true` in the `options` object to render the page with Puppeteer instead of `fetch`.
+The `puppeteer` option defaults to the value of the `USE_PUPPETEER` environment variable if set, otherwise `false`.
 Use `GET /result/:id` to retrieve the stored markdown.
 
 Environment variables:
 - `DOWNLOAD_IMAGES` – set to `true` to download images.
 - `IMAGE_STYLE` – style for image links (`markdown`, `base64`, etc.).
-- `USE_PUPPETEER` – set to `true` to render pages with Puppeteer instead of fetch.
+- `USE_PUPPETEER` – set to `true` to render pages with Puppeteer instead of fetch (can be overridden by the `puppeteer` option).
+
+To use Puppeteer on Linux you may need to install additional system packages. A minimal Debian/Ubuntu setup can be achieved with:
+
+```bash
+apt-get update && apt-get install -y libatk1.0-0 libatk-bridge2.0-0 libx11-xcb1 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libasound2 libpangocairo-1.0-0 libcups2 libgtk-3-0
+```
 
 
 

--- a/server/index.js
+++ b/server/index.js
@@ -25,8 +25,9 @@ app.get('/options', (req, res) => {
 app.post('/clip', async (req, res) => {
   const { url, options = {} } = req.body;
   if (!url) return res.status(400).json({ error: 'url required' });
+  const envUsePuppeteer = process.env.USE_PUPPETEER === 'true';
   const usePuppeteer =
-    options.puppeteer || process.env.USE_PUPPETEER === 'true';
+    typeof options.puppeteer === 'boolean' ? options.puppeteer : envUsePuppeteer;
   try {
     let html;
     if (usePuppeteer) {

--- a/server/markdownload.js
+++ b/server/markdownload.js
@@ -35,12 +35,14 @@ const defaultOptions = {
   contextMenus: true,
   obsidianIntegration: false,
   obsidianVault: "",
-  obsidianFolder: ""
+  obsidianFolder: "",
+  puppeteer: false
 };
 function getOptions(overrides = {}) {
   const envOptions = {};
   if (process.env.DOWNLOAD_IMAGES) envOptions.downloadImages = process.env.DOWNLOAD_IMAGES === 'true';
   if (process.env.IMAGE_STYLE) envOptions.imageStyle = process.env.IMAGE_STYLE;
+  if (process.env.USE_PUPPETEER) envOptions.puppeteer = process.env.USE_PUPPETEER === 'true';
   return { ...defaultOptions, ...envOptions, ...overrides };
 }
 


### PR DESCRIPTION
## Summary
- add a `puppeteer` default option in the server and read `USE_PUPPETEER` from env
- allow request options to override the env variable in `/clip`
- document the behaviour and required packages for running Puppeteer on Linux

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint . -c .eslintrc.json`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866748f4d38832a8d0ddc56a13ac7f0