### PR TITLE
Migrate extension to Chrome MV3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ The extension is available for [Firefox](https://addons.mozilla.org/en-GB/firefo
 
 [![iTunes App Store](https://img.shields.io/itunes/v/1554029832?label=Safari&logo=safari&style=flat)](https://apple.co/3tcU0pD)
 
+## Loading the MV3 extension in Chrome
+
+1. Run `npm run build` inside the `src` directory to package the extension.
+2. Open `chrome://extensions` and enable **Developer mode**.
+3. Click **Load unpacked** and choose the `src` folder.
+
+# Obsidian Integration
+
 # Obsidian Integration
 
 For integration with obsidian, you need to install and enable community plugins named "Advanced Obsidian URI". This plugin help us to bypass character limitation in URL. Because it's using clipboard as the source for creating new file.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "MarkDownload - Markdown Web Clipper",
   "version": "3.4.0",
   "author": "Gordon Pedsersen",
@@ -13,14 +13,17 @@
     "512": "icons/favicon-512x512.png"
   },
   "permissions": [
-    "<all_urls>",
     "activeTab",
     "downloads",
     "storage",
     "contextMenus",
-    "clipboardWrite"
+    "clipboardWrite",
+    "scripting"
   ],
-  "browser_action": {
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "action": {
     "default_title": "MarkDownload",
     "default_popup": "popup/popup.html",
     "default_icon": {
@@ -31,17 +34,16 @@
     }
   },
   "background": {
-    "scripts": [
-      "browser-polyfill.min.js",
-      "background/apache-mime-types.js",
-      "background/moment.min.js",
-      "background/turndown.js",
-      "background/turndown-plugin-gfm.js",
-      "/background/Readability.js",
-      "shared/context-menus.js",
-      "shared/default-options.js",
-      "background/background.js"
-    ]
+    "service_worker": "service-worker.js"
+  },
+  "web_accessible_resources": [{
+    "resources": [
+      "contentScript/pageContext.js"
+    ],
+    "matches": ["<all_urls>"]
+  }],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
   },
   "options_ui": {
     "page": "options/options.html",

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -98,14 +98,17 @@ const showOrHideClipOption = selection => {
 }
 
 const clipSite = id => {
-    return browser.tabs.executeScript(id, { code: "getSelectionAndDom()" })
+    return chrome.scripting.executeScript({
+        target: { tabId: id },
+        func: () => getSelectionAndDom()
+    })
         .then((result) => {
-            if (result && result[0]) {
-                showOrHideClipOption(result[0].selection);
+            if (result && result[0] && result[0].result) {
+                showOrHideClipOption(result[0].result.selection);
                 let message = {
                     type: "clip",
-                    dom: result[0].dom,
-                    selection: result[0].selection
+                    dom: result[0].result.dom,
+                    selection: result[0].result.selection
                 }
                 return browser.storage.sync.get(defaultOptions).then(options => {
                     browser.runtime.sendMessage({
@@ -158,12 +161,14 @@ browser.storage.sync.get(defaultOptions).then(options => {
 }).then((tabs) => {
     var id = tabs[0].id;
     var url = tabs[0].url;
-    browser.tabs.executeScript(id, {
-        file: "/browser-polyfill.min.js"
+    chrome.scripting.executeScript({
+        target: { tabId: id },
+        files: ["/browser-polyfill.min.js"]
     })
     .then(() => {
-        return browser.tabs.executeScript(id, {
-            file: "/contentScript/contentScript.js"
+        return chrome.scripting.executeScript({
+            target: { tabId: id },
+            files: ["/contentScript/contentScript.js"]
         });
     }).then( () => {
         console.info("Successfully injected MarkDownload content script");

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,0 +1,12 @@
+// service worker that imports background dependencies
+importScripts(
+  'browser-polyfill.min.js',
+  'background/apache-mime-types.js',
+  'background/moment.min.js',
+  'background/turndown.js',
+  'background/turndown-plugin-gfm.js',
+  '/background/Readability.js',
+  'shared/context-menus.js',
+  'shared/default-options.js',
+  'background/background.js'
+);


### PR DESCRIPTION
## Summary
- add MV3 service worker
- update manifest for MV3
- switch to chrome.scripting APIs
- update README with instructions for loading MV3 version

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68718d24abc8832a828d38e6f053acda