### PR TITLE
Fix manifest command for Chrome MV3

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -52,7 +52,8 @@
     "open_in_tab": false
   },
   "commands": {
-    "_execute_browser_action": {
+    // Execute the default action (popup) via a keyboard shortcut
+    "_execute_action": {
       "suggested_key": {
         "default": "Alt+Shift+M"
       }

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,4 +1,5 @@
-// service worker that imports background dependencies
+// Service worker that imports background dependencies
+// The default action shortcut (_execute_action) is defined in the manifest
 importScripts(
   'browser-polyfill.min.js',
   'background/apache-mime-types.js',


### PR DESCRIPTION
## Summary
- fix keyboard command for MV3 action in `manifest.json`
- add comment noting the action shortcut in `service-worker.js`

## Testing
- `npm test` in `server`
- `npm run lint` in `server`


------
https://chatgpt.com/codex/tasks/task_e_687767ac446c832a9ed1243b51e1d17d