### PR TITLE
Add documentation for configuration controls and timestamp formatting

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,0 +1,6 @@
+# Requirements
+
+- Allow users to configure the threshold for when conversation history is considered too large. The default limit should be extremely high to accommodate long sessions, but it must remain adjustable.
+- When reasoning-oriented models are selected, expect a higher time to first token and account for it in any timeout or progress handling.
+- Provide an option for the user to select which model is used for generation.
+- Store both the default system prompt and default slash-command prompts in the database. Users may edit these prompts, and any changes must persist to the database.

--- a/WIREFRAMES.md
+++ b/WIREFRAMES.md
@@ -1,0 +1,10 @@
+# Wireframes
+
+## Sample Transcript
+
+```
+2024-05-19 13:45 User: Hello
+2024-05-19 13:46 Assistant: Hi, how can I help?
+```
+
+The transcript timestamps use the `YYYY-MM-DD HH:mm` format.


### PR DESCRIPTION
## Summary
- document history size configuration with large default and model selection
- note higher latency for reasoning models
- update sample transcript timestamp to `YYYY-MM-DD HH:mm`

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68c9602f3ce8832a9eeb2f85eef05a83